### PR TITLE
Add exclusions to D1 minor src pcts_parser change

### DIFF
--- a/notebooks/D1-entitlement-demographics.ipynb
+++ b/notebooks/D1-entitlement-demographics.ipynb
@@ -41,7 +41,7 @@
     "suffix_list = pcts_census_utils.FULL_SUFFIX_LIST\n",
     "\n",
     "remove_prefix = [\"ENV\"]\n",
-    "remove_suffix = [\"EIR\"]\n",
+    "remove_suffix = [\"EIR\",\"IPRO\",\"CA\",\"CATEX\",\"CPIO\",\"CPU\",\"FH\",\"G\",\"HD\",\"HPOZ\",\"ICO\",\"K\",\"LCP\",\"NSO\",\"S\",\"SN\",\"SP\",\"ZAI\"]\n",
     "\n",
     "prefix_list = [x for x in prefix_list if x not in remove_prefix]\n",
     "suffix_list = [x for x in suffix_list if x not in remove_suffix]"

--- a/src/pcts_parser.py
+++ b/src/pcts_parser.py
@@ -258,7 +258,7 @@ class ZoningInfo:
             )
             if self.overlay:
                 assert all([o in VALID_SUPPLEMENTAL_USE for o in self.overlay])
-            assert self.specific_plan in VALID_SPECIFIC_PLAN or self.specific_plan is ""
+            assert self.specific_plan in VALID_SPECIFIC_PLAN or self.specific_plan == ""
         except AssertionError:
             raise ValueError(f"Failed to validate")
 


### PR DESCRIPTION
Minor upfront change to D1 exclusions and changing `is` to `==` to match `src/pcts_parser` to `notebooks/pcts_parser.` More commits to be added to build on pull request as `pcts_census_utils.py` gets adjusted to fix exclusion logic.

This is to address items for #42.